### PR TITLE
Fix infinite loop from future seasons

### DIFF
--- a/Contents/Code/TheTVDBv2.py
+++ b/Contents/Code/TheTVDBv2.py
@@ -239,7 +239,7 @@ def GetMetadata(media, movie, error_log, lang, metadata_source, AniDBid, TVDBid,
     map_min_values = [int(Dict(mappingList, 'season_map')[x]['min']) for x in Dict(mappingList, 'season_map', default={}) for y in Dict(mappingList, 'season_map')[x] if y=='min']
     for entry in Dict(mappingList, 'season_map', default={}):
       entry_min, entry_max = int(mappingList['season_map'][entry]['min']), int(mappingList['season_map'][entry]['max'])
-      while entry_min!=0 and entry_max+1 not in map_min_values + [max_season+1]:  entry_max += 1
+      while entry_min!=0 and entry_max+1 not in map_min_values and entry_max < max_season:  entry_max += 1
       mappingList['season_map'][entry] = {'min': entry_min, 'max': entry_max}
     SaveDict(max_season, mappingList, 'season_map', 'max_season')
 


### PR DESCRIPTION
https://github.com/ZeroQI/Hama.bundle/issues/325
"max_season" is determined from taking the highest season number from all returned episodes from tvdb
"season_map"-->"map_min_values" is determined from "anime-list-master.xml"

So when an anidb series was mapped to a season that did not yet exist in tvdb, it would loop indefinitely as "entry_max+1" would never be in "map_min_values + [max_season+1]".